### PR TITLE
Add Unknown Status Code Literally

### DIFF
--- a/HttpStatusCodes_C++.h
+++ b/HttpStatusCodes_C++.h
@@ -207,7 +207,7 @@ inline std::string reasonPhrase(int code)
 	case 510: return "Not Extended";
 	case 511: return "Network Authentication Required";
 
-	default: return std::string();
+	default: return "Unknown HTTP Status Code";
 	}
 }
 

--- a/HttpStatusCodes_C++11.h
+++ b/HttpStatusCodes_C++11.h
@@ -224,7 +224,7 @@ inline std::string reasonPhrase(int code)
 	case 510: return "Not Extended";
 	case 511: return "Network Authentication Required";
 
-	default: return std::string();
+	default: return "Unknown HTTP Status Code";
 	}
 }
 

--- a/HttpStatusCodes_C.h
+++ b/HttpStatusCodes_C.h
@@ -200,7 +200,7 @@ static const char* HttpStatus_reasonPhrase(int code)
 	case 510: return "Not Extended";
 	case 511: return "Network Authentication Required";
 
-	default: return 0;
+	default: return "Unknown HTTP Status Code";
 	}
 
 }

--- a/HttpStatusCodes_Qt.h
+++ b/HttpStatusCodes_Qt.h
@@ -220,7 +220,7 @@ inline QString reasonPhrase(int code)
 	case 510: return QStringLiteral("Not Extended");
 	case 511: return QStringLiteral("Network Authentication Required");
 
-	default: return QString();
+	default: return QStringLiteral("Unknown HTTP Status Code");
 	}
 }
 


### PR DESCRIPTION
Hi,

You can think like this is both as an issue and PR. For unknown (non-standard) HTTP status codes, your functions return an empty string. Is there a specific reason for this I missed? Because I think, this is a problematic case for logging. What I mean, assume that, a `libcurl` send function failed with a status code. Since this is a failure, the application will try to log (assume syslog like format) with your `reasonPhrase` function. If this is a known status (eg 511) the log will be,

`[2023-03-30 17:04:29.305] [XXX] [error] : Send failed : Network Authentication Required`

but if this is an unknown (non-standard) status the log will be like,

`[2023-03-30 17:04:29.305] [XXX] [error] : Send failed : `

If for default case a string is returned the log will become,

`[2023-03-30 17:04:29.305] [XXX] [error] : Send failed : Unknown HTTP Status Code`

I may agree the application using this library can implement a method by checking length of the string but this means every logging function should check the length before printing so it is a bit complicates the application code. But what do you think about this minor change with this PR?